### PR TITLE
fix: simpleHandler directly return httpresponse once request handled

### DIFF
--- a/src/main/java/com/linkall/core/http/HttpServerImpl.java
+++ b/src/main/java/com/linkall/core/http/HttpServerImpl.java
@@ -79,13 +79,10 @@ public class HttpServerImpl implements HttpServer{
                 if(null == info){
                     i = simHandlerRI;
                 }
-                if(ret) {
-                    request.response().setStatusCode(i.getSuccessCode());
-                    request.response().end(i.getSuccessChunk());
-                }else{
-                    request.response().setStatusCode(i.getFailureCode());
-                    request.response().end(i.getFailureChunk());
-                }
+
+                request.response().setStatusCode(i.getSuccessCode());
+                request.response().end(i.getSuccessChunk());
+
             });
         });
     }


### PR DESCRIPTION
**Changes:**
- simpleHandler directly return httpresponse once request handled

Signed-off-by: Jie Ding <jie.ding@linkall.com>